### PR TITLE
Improve the readability of options in dark mode

### DIFF
--- a/src/components/ThemeSwitch.astro
+++ b/src/components/ThemeSwitch.astro
@@ -14,7 +14,7 @@ import Theme from "@/icons/themeSwitch.astro";
 
 	<div class="group/theme flex items-center gap-2">
 		<label for="themeSwitch" class="flex items-center gap-1 text-sm font-medium leading-6 text-skin-base transition-transform ease-in-out group-hover/theme:rotate-45"> <Theme /></label>
-		<select id="themeSwitch" name="themeSwitch" class="focus:ring-skin-hue ring-skin-muted block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-skin-base ring-1 ring-inset focus:ring-2 sm:text-sm sm:leading-6">
+		<select id="themeSwitch" name="themeSwitch" class="dark:bg-skin-fill dark:text-white focus:ring-skin-hue ring-skin-muted block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-skin-base ring-1 ring-inset focus:ring-2 sm:text-sm sm:leading-6">
 			<option value="system">System</option>
 			<option value="dark">Dark</option>
 			<option value="light">Light</option>


### PR DESCRIPTION
Simple fix that improves the readability of select options in dark mode. The classes "dark:bg-skin-fill dark:text-white" have been added to the select element so that the background and text of the options are visible in dark mode.

![image](https://github.com/user-attachments/assets/c239e3f2-7621-4bcf-958d-2ee6f99f95c5)
